### PR TITLE
fix: Runs Release workflows only on releases and pre-releases publish…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches-ignore:
       - '**'
-    tags:
+    tags-ignore:
       - 'v*.*.*'
       - 'v*.*.*-*'
+  release:
+    types:
+      - released
+      - prereleased
 jobs:
   binary_linux_amd64:
     runs-on: ubuntu-20.04
@@ -40,7 +44,7 @@ jobs:
                TAG=${GITHUB_REF#refs/tags/}
                echo ::set-output name=tag_name::${TAG}
          - name: Publish Binaries
-           uses: svenstaro/upload-release-action@v3
+           uses: svenstaro/upload-release-action@v2
            with:
              repo_token: ${{ secrets.PAT_TOKEN }}
              file: /home/runner/work/bridge-api/bridge-api/bridge-api*
@@ -64,7 +68,7 @@ jobs:
         run: |
             TAG=${GITHUB_REF#refs/tags/}
             echo ::set-output name=tag_name::${TAG}
-      - name: Login to Digital Ocean Registry
+      - name: Login to Dockerhub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Description
- [x] Runs Release workflows only on releases and pre-releases
- [x] Fixes upload bin action dep version

## Related Issue
https://github.com/availproject/bridge-api/actions/runs/8087545768

## Motivation and Context
- Failing builds 
- Adds more fine grain control on builds only triggered by new releases.

## How Has This Been Tested?


## Screenshots (if appropriate)
