### PR TITLE
Adding `chainName` parameter to `get_avl_head` request

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -539,8 +539,8 @@ async fn get_eth_head(State(state): State<Arc<AppState>>) -> impl IntoResponse {
 #[inline(always)]
 async fn get_avl_head(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let url = format!(
-        "{}/{}/?contractChainId={}&contractAddress={}",
-        state.succinct_base_url, "range", state.contract_chain_id, state.contract_address
+        "{}/{}/?chainName={}&contractChainId={}&contractAddress={}",
+        state.succinct_base_url, "range", state.avail_chain_name, state.contract_chain_id, state.contract_address
     );
     let response = state.request_client.get(url).send().await;
     match response {


### PR DESCRIPTION
According to [RPC Queries](https://github.com/succinctlabs/vectorx?tab=readme-ov-file#rpc-queries) from [VectorX](https://github.com/succinctlabs/vectorx), the `chainName` parameter is required when querying.

## Testing

Using the following configuration:
```
AVAIL_CHAIN_NAME=turing
CONTRACT_CHAIN_ID=11155111
VECTORX_CONTRACT_ADDRESS=0xe542db219a7e2b29c7aeaeace242c9a2cd528f96
```

Run this command:

```sh
curl http://localhost:8080/avl/head | jq
```

Expected output:
```
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    38  100    38    0     0     78      0 --:--:-- --:--:-- --:--:--    78
{
  "data": {
    "end": 263160,
    "start": 149761
  }
}
```