### PR TITLE
fix: Installs pg libs + bumps rust img version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM rust:1.76.0-slim AS builder
+FROM rust:1.79.0-slim AS builder
 WORKDIR /build
 COPY . .
 ARG BUILD_PROFILE=release
 
-RUN apt update && apt install -y make libssl-dev pkg-config \
+RUN apt update && apt install -y make libssl-dev pkg-config libpq-dev \
     && cargo build --profile $BUILD_PROFILE --locked \
     && cp /build/target/$BUILD_PROFILE/bridge-api /build/bridge-api
 


### PR DESCRIPTION
# Changes
- [x] Bumps rust img version
- [x] Install pg libs


## Reason for change
- After changes on [v0.2.2-rc1](https://github.com/availproject/bridge-api/releases/tag/v0.2.2-rc1) docker build step [crashed](https://github.com/availproject/bridge-api/actions/runs/12634381966/job/35201996068) due to an unmet dependency.
- Also crate [diesel v2.2.4](https://docs.rs/diesel/2.2.4/diesel/index.html) requires at least rust v1.78.0 for compiling.


## How was it tested?
- Local docker build