### PR TITLE
fix: Adds /transaction endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -848,6 +848,7 @@ async fn main() {
         .route("/avl/head", get(get_avl_head))
         .route("/v1/avl/proof/:block_hash/:message_id", get(get_avl_proof))
         .route("/v1/transactions", get(transactions))
+        .route("/transactions", get(transactions))
         .route("/avl/proof/:block_hash/:message_id", get(get_avl_proof))
         .route("/beacon/slot/:slot_number", get(get_beacon_slot))
         .layer(TraceLayer::new_for_http())


### PR DESCRIPTION
# Changes
- [x] Adds /transaction endpoint


## Reason for Change
- There's an issue one proxy layer that timeouts `/v1/transaction` endpoint. `/transaction` pass through without issues though.

This PR is just to unblock testing while we troubleshoot what's going on in Proxy level.