### PR TITLE
feat: Adds better handling for outdated VectorX contract state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -461,21 +461,30 @@ async fn get_eth_proof(
                 error: Some(data),
                 ..
             }) => {
-                match data.to_string().contains("is not in the range of blocks") {
+                return match data.to_string().contains("is not in the range of blocks") {
                     true => {
-                        tracing::warn!("⏳ Succinct VectorX contract not updated yet, try again in a few minutes");
-                        return (
-                            StatusCode::TOO_EARLY,
-                            [("Cache-Control", format!("max-age={}, must-revalidate", eth_proof_cache_maxage))],
-                            Json(json!({ "error": data })),
+                        tracing::warn!(
+                            "⏳ Succinct VectorX contract not updated yet! Response: {}",
+                            data
                         );
+                        (
+                            StatusCode::TOO_EARLY,
+                            [(
+                                "Cache-Control",
+                                format!("max-age={}, must-revalidate", eth_proof_cache_maxage),
+                            )],
+                            Json(json!({ "error": data })),
+                        )
                     }
                     _ => {
-                        tracing::error!("❌ Succinct API returned unsuccessfully");
-                        return (
+                        tracing::error!(
+                            "❌ Succinct API returned unsuccessfully. Response: {}",
+                            data
+                        );
+                        (
                             StatusCode::NOT_FOUND,
                             [("Cache-Control", "max-age=60, must-revalidate".to_string())],
-                            Json(json!({ "error": data }))
+                            Json(json!({ "error": data })),
                         )
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,7 +463,7 @@ async fn get_eth_proof(
             }) => {
                 match data.to_string().contains("is not in the range of blocks") {
                     true => {
-                        tracing::warn!("Succinct VectorX contract not updated yet, try again in a few minutes");
+                        tracing::warn!("⏳ Succinct VectorX contract not updated yet, try again in a few minutes");
                         return (
                             StatusCode::TOO_EARLY,
                             [("Cache-Control", format!("max-age={}, must-revalidate", eth_proof_cache_maxage))],


### PR DESCRIPTION
# Changes
- [x] Adds better handling for outdated VectorX contract state

## Reason for Change
- Currently Turing Bridge API deployment is spamming several errors which are triggering our alerts. 
These errors could be mitigated by decreasing the severity of Succinct failed api responses log level, whenever VectorX contract block range is outdated (a mapped error case)


## Tests
`/eth/proof` endpoint was debugged locally.
Log stream of cargo run (not debugger!):
```rust
╰─$ cargo run
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.87s
     Running `target/debug/bridge-api`
{"timestamp":"2025-03-25T10:41:50.923656Z","level":"INFO","fields":{"message":"🚀 Listening on 0.0.0.0 port 8080"},"target":"bridge_api"}
{"timestamp":"2025-03-25T10:41:50.923872Z","level":"INFO","fields":{"message":"Starting head tracking task"},"target":"bridge_api"}
{"timestamp":"2025-03-25T10:41:52.599249Z","level":"INFO","fields":{"message":"Beacon mapping: 7263616:7977457"},"target":"bridge_api"}
{"timestamp":"2025-03-25T10:41:58.311278Z","level":"DEBUG","fields":{"message":"started processing request"},"target":"tower_http::trace::on_request","span":{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"},"spans":[{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"}]}
{"timestamp":"2025-03-25T10:42:00.874029Z","level":"WARN","fields":{"message":"Succinct VectorX contract not updated yet, try again in a few minutes"},"target":"bridge_api","span":{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"},"spans":[{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"}]}
{"timestamp":"2025-03-25T10:42:00.874481Z","level":"DEBUG","fields":{"message":"finished processing request","latency":"2563 ms","status":425},"target":"tower_http::trace::on_response","span":{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"},"spans":[{"method":"GET","uri":"/eth/proof/9b3cc74701006254c1fe9f16b65139c1ab8cbcef2ab50b409c69543573ea0929?index=1","version":"HTTP/1.1","name":"request"}]}
```