### PR TITLE
fix: Adds 404 max age cache on bridge api

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ struct AppState {
     avl_head_cache_maxage: u16,
     avl_proof_cache_maxage: u32,
     eth_proof_cache_maxage: u32,
+    eth_proof_failure_cache_maxage: u32,
     slot_mapping_cache_maxage: u32,
     beaconchain_api_key: String,
 }
@@ -240,6 +241,7 @@ async fn get_eth_proof(
     });
 
     let eth_proof_cache_maxage = state.eth_proof_cache_maxage;
+    let eth_proof_failure_cache_maxage = state.eth_proof_failure_cache_maxage;
     let url = format!(
         "{}?chainName={}&contractChainId={}&contractAddress={}&blockHash={}",
         state.succinct_base_url,

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,13 @@ async fn get_eth_proof(
                 tracing::error!("❌ Succinct API returned unsuccessfully");
                 return (
                     StatusCode::NOT_FOUND,
-                    [("Cache-Control", "max-age=60, must-revalidate".to_string())],
+                    [(
+                        "Cache-Control",
+                        format!(
+                            "public, max-age={}, immutable",
+                            eth_proof_failure_cache_maxage
+                        ),
+                    )],
                     Json(json!({ "error": data })),
                 );
             }
@@ -632,6 +638,10 @@ async fn main() {
             .ok()
             .and_then(|proof_response| proof_response.parse::<u32>().ok())
             .unwrap_or(172800),
+        eth_proof_failure_cache_maxage: env::var("ETH_PROOF_FAILURE_CACHE_MAXAGE")
+            .ok()
+            .and_then(|proof_response| proof_response.parse::<u32>().ok())
+            .unwrap_or(5400),
         avl_proof_cache_maxage: env::var("AVL_PROOF_CACHE_MAXAGE")
             .ok()
             .and_then(|proof_response| proof_response.parse::<u32>().ok())


### PR DESCRIPTION
# Changes
- [x] Adds 404 max age cache on bridge api

## Motivation and Context
Currently Bridge API (both on Turing and Mainnet) is being hammered by external users.
The behavior is that they try to pool latest proof status on VectorX (/eth/proof). Since it takes approx 1h30min to get updated on VectorX, most of these requests are the very same 404 and therefore can be cached to ease the bridge-api server.