### PR TITLE
fix: Bumps Ubuntu runners version to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
       - prereleased
 jobs:
   binary_linux_amd64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
          - uses: actions/checkout@v4
          - name: Install Cargo Deps And Build Bridge API
@@ -33,7 +33,7 @@ jobs:
 
   binary_publish:
     needs: [binary_linux_amd64]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
          - uses: actions/download-artifact@v4
            with:
@@ -54,7 +54,7 @@ jobs:
              file_glob: true
 
   docker_build_push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Problem Statement
Build images CI runs are failing due to sunset ubuntu 20.04 version. Bump is mandatory now!