### PR TITLE
fix: Dockerfile build - Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt update && apt install -y make libssl-dev pkg-config libpq-dev \
     && cargo build --profile $BUILD_PROFILE --locked \
     && cp /build/target/$BUILD_PROFILE/bridge-api /build/bridge-api
 
-FROM ubuntu:24.04 as run
+FROM ubuntu:22.04 AS run
 WORKDIR /app
 
 COPY --from=builder /build/bridge-api /usr/local/bin


### PR DESCRIPTION
# Changes
- [x] Rollback Ubuntu version to 22.04

## Reason for change
- Newest Ubuntu v24.04 is breaking on CI due to new shell interpretation. Rollback to 22.04 for the timebeing in order to unblock bridge-api actions.


**Failed Action run (v1.0.0):**
- https://github.com/availproject/bridge-api/actions/runs/15705387070/job/44249888571#logs