### PR TITLE
fix: Bumps builder image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.87-slim AS builder
+FROM rust:1.93-slim AS builder
 WORKDIR /build
 COPY . .
 ARG BUILD_PROFILE=release


### PR DESCRIPTION
# Change
- [x] Bumps builder image version

# Reason for Change
- [Build is failing](https://github.com/availproject/bridge-api/actions/runs/21502017715/job/61950149497) due to outdated rustc version in Dockerfile builder stage