### PR TITLE
feat: support full DATABASE_URL connection string for Postgres

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -840,15 +840,18 @@ async fn main() {
         .and_then(|max_request| max_request.parse::<usize>().ok())
         .unwrap_or(1024);
 
-    let db_url: String = env::var("POSTGRES_URL").unwrap_or("localhost:5432".to_owned());
-    // Connection pool
-    let connections_string = format!(
-        "postgresql://{}:{}@{}/{}",
-        env::var("PG_USERNAME").unwrap_or("avail".to_owned()),
-        env::var("PG_PASSWORD").unwrap_or("avail".to_owned()),
-        db_url,
-        env::var("POSTGRES_DB").unwrap_or("ui-indexer".to_owned()),
-    );
+    // Prefer a full connection string (DATABASE_URL) when provided; otherwise assemble
+    // one from the individual POSTGRES_URL / PG_USERNAME / PG_PASSWORD / POSTGRES_DB parts.
+    let connections_string = env::var("DATABASE_URL").unwrap_or_else(|_| {
+        let db_url = env::var("POSTGRES_URL").unwrap_or("localhost:5432".to_owned());
+        format!(
+            "postgresql://{}:{}@{}/{}",
+            env::var("PG_USERNAME").unwrap_or("avail".to_owned()),
+            env::var("PG_PASSWORD").unwrap_or("avail".to_owned()),
+            db_url,
+            env::var("POSTGRES_DB").unwrap_or("ui-indexer".to_owned()),
+        )
+    });
 
     let db = PgPool::connect(&connections_string)
         .await


### PR DESCRIPTION
## What

Lets bridge-api take a full Postgres **connection string** via `DATABASE_URL`, falling back to the existing assembled-from-parts behaviour when it's unset.

```rust
let connections_string = env::var("DATABASE_URL").unwrap_or_else(|_| {
    // old behaviour: postgresql://{PG_USERNAME}:{PG_PASSWORD}@{POSTGRES_URL}/{POSTGRES_DB}
});
```

## Why

The assembled path derives the database name from `POSTGRES_DB`, which **defaults to `ui-indexer`**. In the hex-infinity deployment that DB doesn't exist (the real one is `bridge-ui-indexer`), so the service crash-loops with `database "ui-indexer" does not exist` → nginx 503.

A single `DATABASE_URL` also lets us embed the db name, `sslmode`, and a connection-pool host in one value — consistent with the indexer / merkle-proof-service / query service, which all use a single `DATABASE_URL` from SSM.

## Compatibility

Fully backward compatible: if `DATABASE_URL` is unset, behaviour is unchanged (POSTGRES_URL/PG_USERNAME/PG_PASSWORD/POSTGRES_DB).

## Rollout

Targets `infinity-bridge` (the branch the current `v2.0.1-rc2` image was built from). After merge, cut `v2.0.1-rc3` to build `availj/bridge-api:v2.0.1-rc3`, then switch the hex-bridge-api helm release to a single `DATABASE_URL` secret.