### PR TITLE
fix: drop trailing slash in get_avl_head range URL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -539,7 +539,7 @@ async fn get_avl_head(
     State(state): State<Arc<AppState>>,
 ) -> Result<impl IntoResponse, ErrorResponse> {
     let url = format!(
-        "{}/{}/?contractChainId={}&contractAddress={}",
+        "{}/{}?contractChainId={}&contractAddress={}",
         state.merkle_proof_service_base_url,
         "range",
         state.contract_chain_id,


### PR DESCRIPTION
## What
`get_avl_head` builds the merkle-proof-service range URL as `{base}/range/?...` (trailing slash). The mps serves `/api/range` (no trailing slash); `/api/range/?...` returns **404 with an empty body**, so the subsequent `.json::<RangeBlocksAPIResponse>()` fails with *error decoding response body* → **500** on `/v1/avl/head`.

## Fix
Drop the trailing slash so it matches the working `fetch_range_blocks` call:
```diff
-        "{}/{}/?contractChainId={}&contractAddress={}",
+        "{}/{}?contractChainId={}&contractAddress={}",
```

Verified: `/api/range?...` → 200 `{"data":{"start":57,"end":18050}}`; `/api/range/?...` → 404 empty.

Targets `infinity-bridge`; will ship as `v2.0.1-rc4`.